### PR TITLE
Fix the signature of connect's onError callback

### DIFF
--- a/lib/adonis_websok.dart
+++ b/lib/adonis_websok.dart
@@ -134,7 +134,7 @@ abstract class AdonisWebsok<S extends Websok> {
   /// Connects to the web socket and sets it up for usage.
   Future<void> connect({
     bool sendRequest = true,
-    void onError(),
+    void onError(error),
     void onDone(),
   }) async {
     if (this.isActive) return null;

--- a/lib/adonis_websok.dart
+++ b/lib/adonis_websok.dart
@@ -295,7 +295,7 @@ abstract class AdonisWebsok<S extends Websok> {
   /// Closes the conexion with the socket.
   void close() {
     this.isActive = false;
-    this.pingPong.cancel();
-    this.socket.close();
+    this.pingPong?.cancel();
+    this.socket?.close();
   }
 }


### PR DESCRIPTION
This PR fixes the exception below when trying to use connect with an onError callback. Only includes the error as I don't think the stack trace is of interest. It also makes the close method more robust with nullable checks.

For this to work we need a new version of the websok package including the PR I created over there which was already merged into master.

```
Invalid argument(s): handleError callback must take either an Object (the error), or both an Object (the error) and a StackTrace
```